### PR TITLE
Fix cookie path default

### DIFF
--- a/ClientApp/src/app/cookie-dialog/cookie-dialog.component.ts
+++ b/ClientApp/src/app/cookie-dialog/cookie-dialog.component.ts
@@ -92,7 +92,7 @@ export class CookieDialogComponent implements OnInit {
     this.setCookie(name, '', -1);
   }
 
-  private setCookie(name: string, value: string, expireDays: number, path: string = 'path=/;') {
+  private setCookie(name: string, value: string, expireDays: number, path: string = '/') {
     let d: Date = new Date();
     d.setTime(d.getTime() + expireDays * 24 * 60 * 60 * 1000);
     let expires: string = `expires=${d.toUTCString()}`;


### PR DESCRIPTION
## Summary
- correct default path parameter for setting cookies

## Testing
- `dotnet build` *(fails: command not found)*
- `npm run build --silent --prefix ClientApp` *(fails: ng not found)*